### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # MacOS 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-x64.yml'
@@ -54,6 +58,12 @@ libretro-build-windows-x64:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # MacOS 64-bit


### PR DESCRIPTION
The libretro buildbot ships no aarch64 Linux build of vitaQuake III, so the core can't be installed from RetroArch's Core Downloader on ARM64 Linux machines (ARM Chromebooks, SBCs, ARM laptops). Nothing blocks it: the build is already interpreter-only (`-DNO_VM_COMPILED`, no `vm_x86.c` in the sources), `COMPILE_ARCH` derives `aarch64` from `uname -m` on its own, the `unix` branch of the Makefile is arch-neutral, and `osx-arm64` already builds these sources for ARM64.

The job mirrors `libretro-build-linux-x64`:

```yaml
# Linux ARM 64-bit
libretro-build-linux-aarch64:
  extends:
    - .libretro-linux-aarch64-make-default
    - .core-defs
```

plus the matching `/linux-aarch64.yml` template include.

Verified natively on aarch64 (postmarketOS, glibc, GCC 15): `make platform=unix` builds clean with no source changes, producing `vitaquake3_libretro.so` (ELF 64-bit ARM aarch64) compiled with `-DARCH_STRING="aarch64"`, and the core loads and initialises. I did not run a map on it - that needs `baseq3` game data I can't redistribute or fetch here, and the core requires a GL context - so this is a build/init verification only.
