### PR TITLE
ci: build for 32-bit x86

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,10 @@ include:
   # Windows 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/windows-x64-mingw.yml'
+
+  # Windows 32-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/windows-i686-mingw.yml'
     
   # Linux 64-bit
   - project: 'libretro-infrastructure/ci-templates'
@@ -23,6 +27,10 @@ include:
   # Linux ARM 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-aarch64.yml'
+
+  # Linux 32-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-i686.yml'
 
   # MacOS 64-bit
   - project: 'libretro-infrastructure/ci-templates'
@@ -53,6 +61,12 @@ libretro-build-windows-x64:
   extends:
     - .libretro-windows-x64-mingw-make-default
     - .core-defs
+
+# Windows 32-bit
+libretro-build-windows-i686:
+  extends:
+    - .libretro-windows-i686-mingw-make-default
+    - .core-defs
     
 # Linux 64-bit
 libretro-build-linux-x64:
@@ -64,6 +78,12 @@ libretro-build-linux-x64:
 libretro-build-linux-aarch64:
   extends:
     - .libretro-linux-aarch64-make-default
+    - .core-defs
+
+# Linux 32-bit
+libretro-build-linux-i686:
+  extends:
+    - .libretro-linux-i686-make-default
     - .core-defs
 
 # MacOS 64-bit

--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -100,11 +100,12 @@ cvar_t  *con_autochat;
 
 #if idx64
 	int (*Q_VMftol)(void);
-#elif id386
-	long (QDECL *Q_ftol)(float f);
-	int (QDECL *Q_VMftol)(void);
-	void (QDECL *Q_SnapVector)(vec3_t vec);
 #endif
+/* The id386 counterparts of these are gone: q_shared.h makes Q_ftol an alias
+ * for lrintf and Q_SnapVector a macro, so declaring pointers by those names
+ * on 32-bit x86 turns into "lrintf redeclared as different kind of symbol".
+ * Nothing reads them either - Com_DetectSSE(), the only thing that ever
+ * assigned them, is commented out below. */
 
 // com_speeds times
 int		time_game;


### PR DESCRIPTION
Adds `linux-i686` and `windows-i686`. Neither was here, and one thing stood in the way of both: the core does not compile for x86-32 at all.

`q_shared.h` makes `Q_ftol` an alias for `lrintf` and `Q_SnapVector` a macro, but `common.c` still declares function pointers by those names under `#elif id386`, left over from ioquake3's runtime SSE selection. On a 32-bit x86 build that reads as:

```
code/qcommon/q_shared.h:440:16: error: 'lrintf' redeclared as different kind of symbol
```

Nothing reads those pointers — `Com_DetectSSE()`, the only thing that ever assigned them, is commented out a couple of thousand lines below. x86_64 never noticed, because it takes the `#if idx64` branch above, which declares only `Q_VMftol`.

Preflight on GitHub Actions, both green: `gcc -m32` with 32-bit libGL for linux-i686 (the closest a runner gets to the i386 image), `i686-w64-mingw32-gcc` for windows-i686.

### On the rest of vitaquake2's matrix

Since the question came up as "can vitaquake3 have what vitaquake2 has": most of it cannot, and it is not about CI. vitaquake2 ships a software renderer, so it reaches 3DS, Wii U, dingux, webOS, Android and iOS. This core is ioquake3 with `renderergl1`, fixed-function desktop GL — `qgl.h` has vitaGL for the Vita, `glsym/switch/nx_gl.h` for the Switch, and `GL/gl.h` everywhere else, with no GLES path anywhere. Every GLES-only target (Android, iOS, tvOS, webOS, emscripten) and every target with no GL at all (3DS, Wii U, dingux) needs a renderer port before it needs a job.

The one further job that does look reachable is `vita` — the platform block is right there in the Makefile and it is this port's original target — but it needs a vitasdk container to check, which is not something a GitHub runner gives me, so I left it out rather than guess.
